### PR TITLE
Allow overriding config defaults

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -6,32 +6,6 @@ if status --is-login
 	end
 end
 
-# Load custom settings for current hostname
-set HOST_SPECIFIC_FILE ~/.config/fish/(hostname).fish
-if test -f $HOST_SPECIFIC_FILE
-   . $HOST_SPECIFIC_FILE
-else 
-   echo Creating host specific file: $HOST_SPECIFIC_FILE
-   touch $HOST_SPECIFIC_FILE
-end
-   
-# Load custom settings for current user
-set USER_SPECIFIC_FILE ~/.config/fish/(whoami).fish
-if test -f $USER_SPECIFIC_FILE
-   . $USER_SPECIFIC_FILE
-else
-   echo Creating user specific file: $USER_SPECIFIC_FILE
-   touch $USER_SPECIFIC_FILE
-end
-
-# Load custom settings for current OS
-set PLATFORM_SPECIFIC_FILE ~/.config/fish/(uname -s).fish
-if test -f $PLATFORM_SPECIFIC_FILE
-   . $PLATFORM_SPECIFIC_FILE
-else
-   echo Creating platform specific file: $PLATFORM_SPECIFIC_FILE
-   touch $PLATFORM_SPECIFIC_FILE
-end  
 
 
 set fish_greeting ""
@@ -96,3 +70,33 @@ set CUSTOM_GEM_PATH "/var/lib/gems/1.8/bin"
 if test -d $CUSTOM_GEM_PATH
     set -x PATH $PATH "/var/lib/gems/1.8/bin"
 end
+
+
+# Load custom settings for current hostname
+set HOST_SPECIFIC_FILE ~/.config/fish/(hostname).fish
+if test -f $HOST_SPECIFIC_FILE
+   . $HOST_SPECIFIC_FILE
+else 
+   echo Creating host specific file: $HOST_SPECIFIC_FILE
+   touch $HOST_SPECIFIC_FILE
+end
+   
+# Load custom settings for current user
+set USER_SPECIFIC_FILE ~/.config/fish/(whoami).fish
+if test -f $USER_SPECIFIC_FILE
+   . $USER_SPECIFIC_FILE
+else
+   echo Creating user specific file: $USER_SPECIFIC_FILE
+   touch $USER_SPECIFIC_FILE
+end
+
+# Load custom settings for current OS
+set PLATFORM_SPECIFIC_FILE ~/.config/fish/(uname -s).fish
+if test -f $PLATFORM_SPECIFIC_FILE
+   . $PLATFORM_SPECIFIC_FILE
+else
+   echo Creating platform specific file: $PLATFORM_SPECIFIC_FILE
+   touch $PLATFORM_SPECIFIC_FILE
+end  
+
+


### PR DESCRIPTION
Moving the load order around - I can now configure the prompt, etc in my user.fish config files.
