### PR TITLE
Fix prompt print in separated git repository

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -44,7 +44,7 @@ function fish_prompt -d "Write out the prompt"
 	end
 
 	# Print git branch
-	if test -d ".git"
+	if test -d ".git" -o -f ".git"
 		printf ' %s%s/%s' (set_color normal) (set_color blue) (parse_git_branch)
 	end
 	printf '%s> ' (set_color normal)


### PR DESCRIPTION
This fixes printing git branch in repository which initialized with
[--separate-git-dir](http://www.kernel.org/pub/software/scm/git/docs/git-init.html#_options) option.
A separated git repository has ".git" file instead of ".git/" directory.
So this applies print git branch to both of them.
