### PR TITLE
Improved prompt when in Git/Subversion repos 

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -45,7 +45,7 @@ function parse_svn_revision
 end
 
 function is_svn
-	svnversion | egrep -vq '^Unversioned directory'
+	svnversion | egrep -vq '^(Unversioned directory|exported)'
 	return $status
 end
 


### PR DESCRIPTION
# Improvements
1. The prompt will show version information when in a Git/Subversion repository even if current directory is not at the root of the checkout. 
2. The Git prompt will show _git describe --tags --always_ e.g. the _tag_, _<tag>-<short-sha1>_, or just the _short-sha1_ when not on a branch.
3. The Git prompt will show the number of commits ahead of the upstream remote branch.
### Git prompt examples:

> rickard@netbook ~/s/fish-shell /OpenBeta_r2-2-g4e3acdc>

In detached mode at a commit following the tag _OpenBeta___r2-2_ with short sha1 _g4e3acdc_.

> rickard@netbook ~/s/auctionsniper /master +1>

On branch master with one commit ahead of the remote branch.
