### PR TITLE
Git branch name improvements

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -71,11 +71,15 @@ function fish_prompt -d "Write out the prompt"
 
 	# Print git tag or branch
 	if is_git
-		printf ' %s%s/%s' (set_color normal) (set_color blue) (parse_git_tag_or_branch)
-		set git_ahead_of_remote (git_parse_ahead_of_remote)
-		if [ -n "$git_ahead_of_remote" -a "$git_ahead_of_remote" != "0" ]
-			printf ' +%s' (git_parse_ahead_of_remote)
-		end
+	set -l branch_count (git branch | wc -l)
+		if test $branch_count -gt 0
+            printf ' %s%s[%s]' (set_color normal) (set_color blue) (parse_git_tag_or_branch)
+			set git_ahead_of_remote (git_parse_ahead_of_remote)
+			if [ -n "$git_ahead_of_remote" -a "$git_ahead_of_remote" != "0" ]
+				printf ' +%s' (git_parse_ahead_of_remote)
+			end
+        end
+
 	end
 	printf '%s> ' (set_color normal)
 end


### PR DESCRIPTION
After initialized an empty git repo, there weren't any branches and I had an error 'test: Missing argument at index 2
' so I added comparison checks if there is at least one branch. I also changed the way to display branch name and put it between two square brackets which is IMO more readable.
