### PR TITLE
Correct ahead message parsing.

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -28,7 +28,7 @@ function parse_git_tag_or_branch
 end
 
 function git_parse_ahead_of_remote
-	git status ^/dev/null | grep 'Your branch is ahead of' | sed -e 's/# Your branch is ahead of .* by \(.*\) commit.*/\1/g'
+	git status ^/dev/null | grep 'Your branch is ahead of' | sed -e 's/.*Your branch is ahead of .* by \(.*\) commit.*/\1/g'
 end
 
 function is_git


### PR DESCRIPTION
At least as of git version 2.2.1, the ahead message is no longer prefixed with `# `, which resulted in very lengthy prompts.

Before:
![screen shot 2015-06-07 at 10 42 58](https://cloud.githubusercontent.com/assets/59671/8024466/df7744be-0d02-11e5-904b-6021f41711fe.png)

After:

![screen shot 2015-06-07 at 10 44 38](https://cloud.githubusercontent.com/assets/59671/8024470/e32e732a-0d02-11e5-8063-8c5424412335.png)

